### PR TITLE
fix: set minhealth to 100% for zero downtime deployment

### DIFF
--- a/.github/workflows/deploy-asg-rolling.yml
+++ b/.github/workflows/deploy-asg-rolling.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           if [ "${{ inputs.environment }}" == "production" ]; then
-            MIN_HEALTHY=50
+            MIN_HEALTHY=100
           else
             MIN_HEALTHY=0
           fi


### PR DESCRIPTION
- 안전한 무중단 배포를 위해 살아 있는 최소 인스턴스 비율을 100%로 설정